### PR TITLE
Prevent package.json churn by telling prettier to ignore package.json (which is formatted during 'npm install')

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 coverage/
 dist/
 node_modules/
+package.json
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -42,22 +42,43 @@
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",
-    "extends": ["react-app", "plugin:import/typescript", "prettier", "plugin:jest-dom/recommended"],
-    "plugins": ["jest-dom", "simple-import-sort", "import"],
+    "extends": [
+      "react-app",
+      "plugin:import/typescript",
+      "prettier",
+      "plugin:jest-dom/recommended"
+    ],
+    "plugins": [
+      "jest-dom",
+      "simple-import-sort",
+      "import"
+    ],
     "settings": {
       "import/resolver": {
         "typescript": {}
       }
     },
     "rules": {
-      "arrow-body-style": ["error", "as-needed"],
-      "array-bracket-spacing": ["error", "never"],
+      "arrow-body-style": [
+        "error",
+        "as-needed"
+      ],
+      "array-bracket-spacing": [
+        "error",
+        "never"
+      ],
       "arrow-spacing": "error",
       "brace-style": "error",
       "camelcase": "error",
-      "comma-dangle": ["error", "always-multiline"],
+      "comma-dangle": [
+        "error",
+        "always-multiline"
+      ],
       "curly": "error",
-      "eol-last": ["error", "always"],
+      "eol-last": [
+        "error",
+        "always"
+      ],
       "eqeqeq": "error",
       "import/first": "error",
       "import/newline-after-import": "error",
@@ -72,7 +93,10 @@
           "SwitchCase": 1
         }
       ],
-      "jsx-quotes": ["error", "prefer-double"],
+      "jsx-quotes": [
+        "error",
+        "prefer-double"
+      ],
       "key-spacing": [
         "error",
         {
@@ -80,7 +104,10 @@
           "afterColon": true
         }
       ],
-      "linebreak-style": ["error", "unix"],
+      "linebreak-style": [
+        "error",
+        "unix"
+      ],
       "max-len": [
         "error",
         {
@@ -88,7 +115,10 @@
           "comments": 120
         }
       ],
-      "max-params": ["error", 4],
+      "max-params": [
+        "error",
+        4
+      ],
       "no-alert": "error",
       "no-console": "error",
       "no-const-assign": "error",
@@ -124,15 +154,32 @@
           "avoidEscape": true
         }
       ],
-      "semi": ["error", "always"],
+      "semi": [
+        "error",
+        "always"
+      ],
       "simple-import-sort/sort": "error",
-      "space-in-parens": ["error", "never"],
-      "spaced-comment": ["error", "always"]
+      "space-in-parens": [
+        "error",
+        "never"
+      ],
+      "spaced-comment": [
+        "error",
+        "always"
+      ]
     }
   },
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all"],
-    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   },
   "jest": {
     "collectCoverageFrom": [
@@ -178,7 +225,11 @@
         "statements": 100
       }
     },
-    "coverageReporters": ["text", "text-summary", "html"]
+    "coverageReporters": [
+      "text",
+      "text-summary",
+      "html"
+    ]
   },
   "devDependencies": {
     "@babel/core": "7.6.4",


### PR DESCRIPTION
Fixes #28